### PR TITLE
Fix mutate global test not actually testing whether global was mutated.

### DIFF
--- a/test/test.js
+++ b/test/test.js
@@ -1,5 +1,10 @@
 var assert = require('chai').assert;
 var noop = require('..');
+var util = require('util');
+
+function getStringRepresentation(obj) {
+  return util.inspect(obj, {depth: null});
+}
 
 describe('noop', function() {
   it('should be a function', function() {
@@ -10,8 +15,8 @@ describe('noop', function() {
     assert.isUndefined(noop.noop("some args", 1, 2, [3]));
   });
   it('should not mutate global', function() {
-    var globalBefore = global;
+    var globalBefore = getStringRepresentation(global);
     noop.noop();
-    assert.equal(globalBefore, global);
+    assert.equal(globalBefore, getStringRepresentation(global));
   });
 });


### PR DESCRIPTION
Previously this test was just testing via object reference so even if global was mutated (such as by adding a property) the test would pass.

This PR modifies the test to fail when the object is mutated. Ideally you would make a deep copy of the object and compare equality via deepEqual. Unfortunately copying failed when using the 'copy' module. I then thought about using Object.assign however this just makes a shallow copy. Next I tried JSON.stringify however this fails on circular references. 

Finally I settled on util.inspect. The test is rather slow (150ms) however the test suite is still fast overall and this PR fixes 33% of the tests so it seems worth it.